### PR TITLE
Feat/custom errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@discordjs/voice": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,29 @@
+/* eslint-disable max-classes-per-file */
+import { Message } from 'discord.js';
+
+class ReplyError extends Error {
+    public replyMessage: string;
+
+    constructor(replyMessage: string) {
+        super();
+        this.replyMessage = replyMessage;
+        this.message = 'ReplyError';
+    }
+}
+
+const isReplyError = (
+    err: unknown,
+): err is ReplyError => err instanceof ReplyError;
+
+const sendErrorMessage = (message: Message, err: unknown): void => {
+    if (isReplyError(err)) {
+        message.reply(err.replyMessage);
+    } else {
+        message.reply('Unexpected Error');
+    }
+};
+
+export {
+    ReplyError,
+    sendErrorMessage,
+};

--- a/src/handlers/commandHandlers/sound/play.ts
+++ b/src/handlers/commandHandlers/sound/play.ts
@@ -1,75 +1,81 @@
-import { joinVoiceChannel } from '@discordjs/voice';
+import { VoiceConnection, joinVoiceChannel } from '@discordjs/voice';
 import { Message } from 'discord.js';
 import { Logger } from 'pino';
 import { getDetails } from '../../../helpers/inputHelpers';
 import player from '../../../lib/Player';
-import { isValidPlayMessage } from '../../../helpers/validators';
+import { MessageWithField, isValidPlayMessage } from '../../../helpers/validators';
+import { ReplyError, sendErrorMessage } from '../../../errors';
 
-const play = async (message: Message, logger: Logger): Promise<void> => {
-    logger.info({ msg: 'Handling Play Command' });
-
+const ensureValidPlayMessage = (message: Message, logger: Logger): MessageWithField => {
     if (!isValidPlayMessage(message)) {
-        logger.warn({ msg: 'Message not in useable format' });
-        message.reply('Message not in usable format');
-        return;
+        const errorMessage = 'Message not in usable format';
+        logger.error({ msg: errorMessage });
+        throw new ReplyError(errorMessage);
     }
+    return message;
+};
 
+const ensureQueueLengthBelowMax = (logger: Logger) : void => {
     const queue = player.getQueue();
     if (queue.length >= 20) {
-        logger.warn({ msg: 'Max quesize reached' });
-        message.reply('Play queue at max size');
-        return;
+        const errorMessage = 'Max Queue size reached';
+        logger.error({ msg: errorMessage });
+        throw new ReplyError(errorMessage);
     }
+};
 
-    const url = getDetails(message);
-    await player.addToQueue(url);
-
+const joinChannel = (message: MessageWithField, logger: Logger): VoiceConnection => {
     logger.info({ msg: 'Joining Voice Channel' });
-    const connection = joinVoiceChannel({
+    return joinVoiceChannel({
         channelId: message.member.voice.channelId || '',
         guildId: message.guildId,
         adapterCreator: message.guild.voiceAdapterCreator,
     });
+};
 
+const subscribeToChannel = (connection: VoiceConnection, logger: Logger): void => {
     logger.info({ msg: 'Subscribing player to Voice Channel' });
     const subscription = connection.subscribe(player.returnInstance());
 
     if (subscription) {
-        logger.info({ msg: 'Playing Audio' });
+        logger.info({ msg: 'Connection Subscribed' });
+    }
+};
+
+const play = async (message: Message, logger: Logger): Promise<void> => {
+    logger.info({ msg: 'Handling Play Command' });
+    try {
+        // TS does not recognise nested type predicate, needs a relook
+        const messageWithField = ensureValidPlayMessage(message, logger);
+        ensureQueueLengthBelowMax(logger);
+
+        const url = getDetails(messageWithField);
+        await player.addToQueue(url);
+
+        const voiceConnection = joinChannel(messageWithField, logger);
+        subscribeToChannel(voiceConnection, logger);
+    } catch (err) {
+        sendErrorMessage(message, err);
+        logger.error({ msg: 'Error handling Play command', error: err });
     }
 };
 
 const forcePlay = async (message: Message, logger: Logger): Promise<void> => {
     logger.info({ msg: 'Handling Force Play Command' });
 
-    if (!isValidPlayMessage(message)) {
-        logger.warn({ msg: 'Message not in usable format' });
-        message.reply('Message not in usable format');
-        return;
-    }
+    try {
+        // TS does not recognise nested type predicate, needs a relook
+        const messageWithField = ensureValidPlayMessage(message, logger);
+        ensureQueueLengthBelowMax(logger);
 
-    const queue = player.getQueue();
-    if (queue.length >= 20) {
-        logger.warn({ msg: 'Max quesize reached' });
-        message.reply('Play queue at max size');
-        return;
-    }
+        const url = getDetails(messageWithField);
+        await player.forcePlay(url);
 
-    const url = getDetails(message);
-    await player.forcePlay(url);
-
-    logger.info({ msg: 'Joining Voice Channel' });
-    const connection = joinVoiceChannel({
-        channelId: message.member.voice.channelId || '',
-        guildId: message.guildId,
-        adapterCreator: message.guild.voiceAdapterCreator,
-    });
-
-    logger.info({ msg: 'Subscribing player to Voice Channel' });
-    const subscription = connection.subscribe(player.returnInstance());
-
-    if (subscription) {
-        logger.info({ msg: 'Playing Audio' });
+        const voiceConnection = joinChannel(messageWithField, logger);
+        subscribeToChannel(voiceConnection, logger);
+    } catch (err) {
+        sendErrorMessage(message, err);
+        logger.error({ msg: 'Error handling Force Play command', error: err });
     }
 };
 

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -20,4 +20,4 @@ const isValidUrl = (message: Message): boolean => {
 // eslint-disable-next-line max-len
 const isValidPlayMessage = (message: Message): message is MessageWithField => isUsableMessage(message) && isValidUrl(message);
 
-export { isValidPlayMessage };
+export { isValidPlayMessage, MessageWithField };


### PR DESCRIPTION
## Description
<!-- Describe the changes in the PR -->
- Custom Error
  - Added `ReplyError` class, which has a `replyMessage` for discord error replies
  - Added handler to check if this message exists, otherwise return default error
- Cleanup `play` and `forcePlay` commands
  - Reuse code

Bug in TS type predicates, where type predicate in a nested function is not being seen in a parent function
## Type of Change

- [ ] Bug fix 
- [x] New feature
- [ ] Tests 
- [ ] CI
- [ ] Docs


## Links
- https://trello.com/c/ZrFZ3IFk/3-error-handling
<!-- Include links to trello ticket or any important links -->